### PR TITLE
Move browser-specific capabilities into their own classes

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,15 +6,13 @@ require "./support/**"
 
 class Global
   @@driver : Selenium::Driver?
-  @@cap : Selenium::Capabilities?
+  @@args : Array(String)?
 
-  def self.set(driver, cap)
-    @@driver = driver
-    @@cap = cap
+  def self.set(@@driver, @@args)
   end
 
   def self.create_session
-    @@driver.not_nil!.create_session(@@cap)
+    @@driver.not_nil!.create_session(args: @@args.not_nil!)
   end
 
   def self.stop
@@ -22,8 +20,8 @@ class Global
   end
 end
 
-driver, capabilities = Selenium::TestDriverFactory.build(ENV["SELENIUM_BROWSER"]? || "chrome")
-Global.set(driver, capabilities)
+driver, args = Selenium::TestDriverFactory.build(ENV["SELENIUM_BROWSER"]? || "chrome")
+Global.set(driver, args)
 
 server = TestServer.new(3002)
 

--- a/spec/support/test_driver_factory.cr
+++ b/spec/support/test_driver_factory.cr
@@ -1,5 +1,5 @@
 class Selenium::TestDriverFactory
-  def self.build(browser) : Tuple(Driver, Capabilities)
+  def self.build(browser) : Tuple(Driver, Array(String))
     case browser
     when "chrome"
       build_chrome_driver
@@ -14,29 +14,23 @@ class Selenium::TestDriverFactory
     end
   end
 
-  def self.build_chrome_driver : Tuple(Driver, Capabilities)
-    capabilities = Chrome::Capabilities.new
-    capabilities.args(["no-sandbox", "headless", "disable-gpu"])
+  def self.build_chrome_driver : Tuple(Driver, Array(String))
     driver = Driver.for(:chrome, service: Service.chrome(driver_path: Webdrivers::Chromedriver.install))
-    {driver, capabilities}
+    {driver, ["no-sandbox", "headless", "disable-gpu"]}
   end
 
-  def self.build_firefox_driver : Tuple(Driver, Capabilities)
-    capabilities = Firefox::Capabilities.new
-    capabilities.args(["-headless"])
+  def self.build_firefox_driver : Tuple(Driver, Array(String))
     driver = Driver.for(:firefox, service: Service.firefox(driver_path: Webdrivers::Geckodriver.install))
-    {driver, capabilities}
+    {driver, ["-headless"]}
   end
 
-  def self.build_chrome_driver_no_service : Tuple(Driver, Capabilities)
-    capabilities = Chrome::Capabilities.new
-    capabilities.args(["no-sandbox", "headless", "disable-gpu"])
+  def self.build_chrome_driver_no_service : Tuple(Driver, Array(String))
     driver = Driver.for(:chrome, base_url: "http://localhost:9515")
-    {driver, capabilities}
+    {driver, ["no-sandbox", "headless", "disable-gpu"]}
   end
 
-  def self.build_safari_driver : Tuple(Driver, Capabilities)
+  def self.build_safari_driver : Tuple(Driver, Array(String))
     driver = Driver.for(:safari, service: Service.safari(driver_path: "/usr/bin/safaridriver"))
-    {driver, Safari::Capabilities.new}
+    {driver, [] of String}
   end
 end

--- a/src/selenium/chrome/capabilities.cr
+++ b/src/selenium/chrome/capabilities.cr
@@ -1,9 +1,24 @@
 class Selenium::Chrome::Capabilities < Selenium::Capabilities
-  @[JSON::Field(key: "goog:chromeOptions")]
-  property chrome_options = {"args" => [] of String}
   @browser_name = "chrome"
 
-  def args(args)
-    chrome_options["args"] = args
+  @[JSON::Field(key: "goog:chromeOptions")]
+  property chrome_options = ChromeOptions.new
+
+  class ChromeOptions
+    include JSON::Serializable
+
+    def initialize
+    end
+
+    property args = [] of String
+
+    property binary : String?
+
+    property extensions : Array(String)?
+
+    property detach : Bool?
+
+    @[JSON::Field(key: "debuggerAddress")]
+    property debugger_address : String?
   end
 end

--- a/src/selenium/chrome/driver.cr
+++ b/src/selenium/chrome/driver.cr
@@ -2,4 +2,10 @@ class Selenium::Chrome::Driver < Selenium::Driver
   def create_session(capabilities : Chrome::Capabilities) : Session
     super(capabilities)
   end
+
+  def create_session(args : Array(String)) : Session
+    capabilities = Chrome::Capabilities.new
+    capabilities.chrome_options.args = args
+    create_session(capabilities)
+  end
 end

--- a/src/selenium/driver.cr
+++ b/src/selenium/driver.cr
@@ -4,7 +4,7 @@
 #
 # If you passed in a `Selenium::Service` you *MUST* call `Selenium::Driver#stop` when you are done to stop the service
 # or else the process it starts will continue running on your computer after the program ends
-class Selenium::Driver
+abstract class Selenium::Driver
   # *browser* options:
   # - :chrome (see `Selenium::Chrome::Driver`)
   # - :firefox or :gecko (see `Selenium::Firefox::Driver`)
@@ -35,6 +35,8 @@ class Selenium::Driver
     @http_client = HttpClient.new(base_url: base_url)
     @command_handler = CommandHandler.new(@http_client)
   end
+
+  abstract def create_session(args : Array(String)) : Session
 
   def create_session(capabilities, retry = true) : Session
     parameters = {capabilities: {alwaysMatch: capabilities}}

--- a/src/selenium/firefox/capabilities.cr
+++ b/src/selenium/firefox/capabilities.cr
@@ -1,9 +1,15 @@
 class Selenium::Firefox::Capabilities < Selenium::Capabilities
-  @[JSON::Field(key: "moz:firefoxOptions")]
-  property firefox_options = {"args" => [] of String}
   @browser_name = "firefox"
 
-  def args(args)
-    firefox_options["args"] = args
+  @[JSON::Field(key: "moz:firefoxOptions")]
+  property firefox_options = FirefoxOptions.new
+
+  class FirefoxOptions
+    include JSON::Serializable
+
+    def initialize
+    end
+
+    property args = [] of String
   end
 end

--- a/src/selenium/firefox/driver.cr
+++ b/src/selenium/firefox/driver.cr
@@ -2,4 +2,10 @@ class Selenium::Firefox::Driver < Selenium::Driver
   def create_session(capabilities : Firefox::Capabilities) : Session
     super(capabilities)
   end
+
+  def create_session(args : Array(String)) : Session
+    capabilities = Firefox::Capabilities.new
+    capabilities.firefox_options.args = args
+    create_session(capabilities)
+  end
 end

--- a/src/selenium/remote/driver.cr
+++ b/src/selenium/remote/driver.cr
@@ -1,2 +1,5 @@
 class Selenium::Remote::Driver < Selenium::Driver
+  def create_session(args : Array(String)) : Session
+    create_session(Selenium::Capabilities.new)
+  end
 end

--- a/src/selenium/safari/driver.cr
+++ b/src/selenium/safari/driver.cr
@@ -2,4 +2,8 @@ class Selenium::Safari::Driver < Selenium::Driver
   def create_session(capabilities : Safari::Capabilities) : Session
     super(capabilities)
   end
+
+  def create_session(args : Array(String)) : Session
+    create_session(Safari::Capabilities.new)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/matthewmcgarvey/selenium.cr/issues/14

The static typing was making it impossible to add to the hash anything other than string values. Ideally, I wish we had some sort of JSON type that had simple methods for users to add values into so that I didn't have to define every single property. The other alternative would be to provide a method and double splat the params so users could provide any option. To be honest, I don't have the interest in figuring out the API right now and I just wanted to get it working. I did provide a helper method to be able to create the session just by passing in args, though.