### PR TITLE
Add support for additional location strategies

### DIFF
--- a/spec/features/element_retrieval_spec.cr
+++ b/spec/features/element_retrieval_spec.cr
@@ -24,6 +24,28 @@ module Selenium::Command
       end
     end
 
+    it "can retrieve a single element by extra strategies" do
+      TestServer.route "/home", <<-HTML
+      <ul>
+        <li name="item-0">
+          <p id="word0">First Item</p>
+        </li>
+        <li name="item-1">
+          <p id="word1" style="text-align:center;">Second Item</p>
+        </li>
+      </ul>
+      HTML
+
+      with_session do |session|
+        session.navigate_to("http://localhost:3002/home")
+        element = session.find_element(:name, "item-1")
+        child_element = element.find_child_element(:id, "word1")
+        child_element.text.should eq("Second Item")
+        child_element.tag_name.should eq("p")
+        child_element.css_value("text-align").should eq("center")
+      end
+    end
+
     it "can retrieve multiple elements" do
       TestServer.route "/home", <<-HTML
       <ul>
@@ -44,6 +66,33 @@ module Selenium::Command
 
         element = session.find_element(:css, "[data-testid=\"item-0\"]")
         child_elements = element.find_child_elements(:css, "p")
+        child_elements.size.should eq(2)
+        child_element_texts = child_elements.map &.text
+        child_element_texts.should contain("First Item")
+        child_element_texts.should contain("Sub Text")
+      end
+    end
+
+    it "can retrieve multiple elements by extra strategies" do
+      TestServer.route "/home", <<-HTML
+      <ul>
+        <li class="item-0">
+          <p name="child" id="words">First Item</p>
+          <p name="child">Sub Text</p>
+        </li>
+        <li class="item-1">
+          <p name="child" id="words">Second Item</p>
+        </li>
+      </ul>
+      HTML
+
+      with_session do |session|
+        session.navigate_to("http://localhost:3002/home")
+        elements = session.find_elements(:id, "words")
+        elements.size.should eq(2)
+
+        element = session.find_element(:class, "item-0")
+        child_elements = element.find_child_elements(:name, "child")
         child_elements.size.should eq(2)
         child_element_texts = child_elements.map &.text
         child_element_texts.should contain("First Item")

--- a/src/selenium/element.cr
+++ b/src/selenium/element.cr
@@ -51,6 +51,7 @@ class Selenium::Element
   end
 
   def find_child_element(using : Symbol, value)
+    using, value = LocationStrategy.transform_extra_strategies(using, value)
     find_child_element(LocationStrategy.from_symbol(using), value)
   end
 
@@ -67,6 +68,7 @@ class Selenium::Element
   end
 
   def find_child_elements(using : Symbol, value)
+    using, value = LocationStrategy.transform_extra_strategies(using, value)
     find_child_elements(LocationStrategy.from_symbol(using), value)
   end
 

--- a/src/selenium/location_strategy.cr
+++ b/src/selenium/location_strategy.cr
@@ -5,6 +5,21 @@ enum Selenium::LocationStrategy
   TAG_NAME
   XPATH
 
+  def self.transform_extra_strategies(symbol : Symbol, value : String) : {Symbol, String}
+    case symbol
+    when :class
+      symbol = :css
+      value = ".#{value}"
+    when :id
+      symbol = :css
+      value = "##{value}"
+    when :name
+      symbol = :xpath
+      value = ".//*[@name='#{value}']"
+    end
+    {symbol, value}
+  end
+
   def self.from_symbol(symbol)
     case symbol
     when :css
@@ -18,7 +33,7 @@ enum Selenium::LocationStrategy
     when :xpath
       XPATH
     else
-      raise ArgumentError.new
+      raise ArgumentError.new("Unsupported location strategy: #{symbol}")
     end
   end
 

--- a/src/selenium/session.cr
+++ b/src/selenium/session.cr
@@ -45,6 +45,7 @@ class Selenium::Session
   end
 
   def find_element(using : Symbol, value)
+    using, value = LocationStrategy.transform_extra_strategies(using, value)
     find_element(LocationStrategy.from_symbol(using), value)
   end
 
@@ -61,6 +62,7 @@ class Selenium::Session
   end
 
   def find_elements(using : Symbol, value)
+    using, value = LocationStrategy.transform_extra_strategies(using, value)
     find_elements(LocationStrategy.from_symbol(using), value)
   end
 


### PR DESCRIPTION
This PR adds support for three additional element location strategies that are not part of WebDriver HTTP protocol, but are a "syntax sugar" provided by the client libraries for [other programming languages](https://www.selenium.dev/documentation/en/webdriver/locating_elements/).

The added strategies are `id`, `name` and `class`. They've been added only to `find_*`methods using `Symbol` (not the `LocationStrategy`). That's not to introduce additional complexity, and to leave the `LocationStragegy` consistent with the WebDriver protocol. This is a design decision that is easy to change if needed though.

As a sidenote: thanks for the great job on this project! It's a cornerstone of my Page Object Model shard: https://github.com/bwilczek/webdriver_pump, that you might want to check out.