### PR TITLE
Add new manager to interact with WebStorage

### DIFF
--- a/spec/features/web_storage_spec.cr
+++ b/spec/features/web_storage_spec.cr
@@ -1,0 +1,75 @@
+require "../spec_helper"
+
+module Selenium::Command
+  describe "WebStorageManager", tags: "feature" do
+    it "works for localStorage" do
+      TestServer.route "/home", "<h1>The Title</h1>"
+
+      with_session do |session|
+        session.navigate_to("http://localhost:3002/home")
+        local_storage_manager = session.local_storage_manager
+
+        local_storage_manager.item("foo", "null")
+        item = local_storage_manager.item("foo")
+        item.should eq("null")
+
+        local_storage_manager.size.should eq(1)
+
+        local_storage_manager.item("fizz", "buzz")
+        item = local_storage_manager.item("fizz")
+        item.should eq("buzz")
+
+        local_storage_manager.size.should eq(2)
+
+        local_storage_manager.item("foo", "bazz")
+        item = local_storage_manager.item("foo")
+        item.should eq("bazz")
+
+        names = local_storage_manager.keys
+        names.should eq(["foo", "fizz"])
+
+        # local_storage_manager.remove("fizz")
+        # item = local_storage_manager.item("fizz")
+        # item.should be_nil
+
+        local_storage_manager.clear
+        local_storage_manager.size.should eq(0)
+      end
+    end
+
+    it "works for sessionStorage" do
+      TestServer.route "/home", "<h1>The Title</h1>"
+
+      with_session do |session|
+        session.navigate_to("http://localhost:3002/home")
+        session_storage_manager = session.session_storage_manager
+
+        session_storage_manager.item("foo", "null")
+        item = session_storage_manager.item("foo")
+        item.should eq("null")
+
+        session_storage_manager.size.should eq(1)
+
+        session_storage_manager.item("fizz", "buzz")
+        item = session_storage_manager.item("fizz")
+        item.should eq("buzz")
+
+        session_storage_manager.size.should eq(2)
+
+        session_storage_manager.item("foo", "bazz")
+        item = session_storage_manager.item("foo")
+        item.should eq("bazz")
+
+        names = session_storage_manager.keys
+        names.should eq(["foo", "fizz"])
+
+        # session_storage_manager.remove("fizz")
+        # item = session_storage_manager.item("fizz")
+        # item.should be_nil
+
+        session_storage_manager.clear
+        session_storage_manager.size.should eq(0)
+      end
+    end
+  end
+end

--- a/spec/features/web_storage_spec.cr
+++ b/spec/features/web_storage_spec.cr
@@ -9,9 +9,9 @@ module Selenium::Command
         session.navigate_to("http://localhost:3002/home")
         local_storage_manager = session.local_storage_manager
 
-        local_storage_manager.item("foo", "null")
+        local_storage_manager.item("foo", "barr")
         item = local_storage_manager.item("foo")
-        item.should eq("null")
+        item.should eq("barr")
 
         local_storage_manager.size.should eq(1)
 
@@ -28,10 +28,6 @@ module Selenium::Command
         names = local_storage_manager.keys
         names.should eq(["foo", "fizz"])
 
-        # local_storage_manager.remove("fizz")
-        # item = local_storage_manager.item("fizz")
-        # item.should be_nil
-
         local_storage_manager.clear
         local_storage_manager.size.should eq(0)
       end
@@ -44,9 +40,9 @@ module Selenium::Command
         session.navigate_to("http://localhost:3002/home")
         session_storage_manager = session.session_storage_manager
 
-        session_storage_manager.item("foo", "null")
+        session_storage_manager.item("foo", "barr")
         item = session_storage_manager.item("foo")
-        item.should eq("null")
+        item.should eq("barr")
 
         session_storage_manager.size.should eq(1)
 
@@ -62,10 +58,6 @@ module Selenium::Command
 
         names = session_storage_manager.keys
         names.should eq(["foo", "fizz"])
-
-        # session_storage_manager.remove("fizz")
-        # item = session_storage_manager.item("fizz")
-        # item.should be_nil
 
         session_storage_manager.clear
         session_storage_manager.size.should eq(0)

--- a/src/selenium/session.cr
+++ b/src/selenium/session.cr
@@ -31,7 +31,7 @@ class Selenium::Session
   end
 
   def session_storage_manager
-    WebStorageManager.new(document_manager, WebStorageManager::StorageType::LocalStorage)
+    WebStorageManager.new(document_manager, WebStorageManager::StorageType::SessionStorage)
   end
 
   def delete

--- a/src/selenium/session.cr
+++ b/src/selenium/session.cr
@@ -26,6 +26,14 @@ class Selenium::Session
     AlertManager.new(command_handler, id)
   end
 
+  def local_storage_manager
+    WebStorageManager.new(document_manager, WebStorageManager::StorageType::LocalStorage)
+  end
+
+  def session_storage_manager
+    WebStorageManager.new(document_manager, WebStorageManager::StorageType::LocalStorage)
+  end
+
   def delete
     command_handler.execute(:delete_session, path_variables)
   end

--- a/src/selenium/web_storage_manager.cr
+++ b/src/selenium/web_storage_manager.cr
@@ -1,0 +1,49 @@
+class Selenium::WebStorageManager
+  enum StorageType
+    LocalStorage
+    SessionStorage
+  end
+
+  getter document_manager : DocumentManager
+
+  forward_missing_to @document_manager
+
+  def initialize(@document_manager, @storage : StorageType = StorageType::LocalStorage)
+  end
+
+  # Clear all items from the Storage
+  def clear
+    document_manager.execute_script("#{storage_type_in_js}.clear()")
+  end
+
+  # Retrieve and insert item from/into the Storage.
+  # If no value is given, it will return the item specified in `name`.
+  # For a given `value`, it will be added or updated for the item specified in `name`.
+  def item(name : String, value = nil) : String | Nil
+    if value.nil?
+      document_manager.execute_script("return #{storage_type_in_js}.getItem('#{name}')")
+    else
+      document_manager.execute_script("#{storage_type_in_js}.setItem('#{name}', '#{value}')")
+    end
+  end
+
+  # Retrieve the list of keys from the Storage
+  def keys
+    document_manager.execute_script("return Object.keys(#{storage_type_in_js})")
+  end
+
+  # Remove the item specified in `name` from the Storage
+  def remove(name : String)
+    document_manager.execute_script("#{storage_type_in_js}.removeItem('#{name}')")
+  end
+
+  # Retrieve the number of items in the Storage
+  def size : Int
+    document_manager.execute_script("return #{storage_type_in_js}.length").to_i
+  end
+
+  # TODO: Add doc
+  private def storage_type_in_js
+    "window.#{@storage.to_s.camelcase(lower: true)}"
+  end
+end

--- a/src/selenium/web_storage_manager.cr
+++ b/src/selenium/web_storage_manager.cr
@@ -28,8 +28,9 @@ class Selenium::WebStorageManager
   end
 
   # Retrieve the list of keys from the Storage
-  def keys
-    document_manager.execute_script("return Object.keys(#{storage_type_in_js})")
+  def keys : JSON::Any
+    str = document_manager.execute_script("return Object.keys(#{storage_type_in_js})")
+    JSON.parse(str)
   end
 
   # Remove the item specified in `name` from the Storage


### PR DESCRIPTION
Fixes #19 

## Description

Little change to allow access to the LocalStorage and SessionStorage. The WebStorage is accessible via HTTP endpoints, so we send a JS script for the browser to run.
The code structure is heavily inspired by what is done on https://github.com/SeleniumHQ/selenium/blob/de7acb9099f42f8aaa1a4f7bf5d00e3c102947ae/rb/lib/selenium/webdriver/remote/bridge.rb#L278

## How it was tested?
Locally by running headless Firefox

