### PR TITLE
Update to run multiple instances of same webdriver

### DIFF
--- a/spec/features/session_spec.cr
+++ b/spec/features/session_spec.cr
@@ -1,0 +1,33 @@
+require "../spec_helper"
+
+module Selenium::Command
+  describe "session", tags: "feature" do
+    it "run multiple browsers on separate process" do
+      TestServer.route "/home", "<h1>The Title</h1>"
+      TestServer.route "/next-page", "<h1>You made it!</h1>"
+      TestServer.route "/action-page", <<-HTML
+        <a href="/next-page">Click Me!</a>
+      HTML
+
+      begin
+        driver1, args1 = Selenium::TestDriverFactory.build(ENV["SELENIUM_BROWSER"]? || "chrome")
+        session1 = driver1.not_nil!.create_session(args: args1.not_nil!)
+        driver2, args2 = Selenium::TestDriverFactory.build(ENV["SELENIUM_BROWSER"]? || "chrome")
+        session2 = driver2.not_nil!.create_session(args: args2.not_nil!)
+
+        session1.navigate_to("http://localhost:3002/home")
+        session2.navigate_to("http://localhost:3002/action-page")
+        element = session2.find_element(:link_text, "Click Me!")
+        element.click
+        session1.current_url.should eq("http://localhost:3002/home")
+        session2.current_url.should eq("http://localhost:3002/next-page")
+      ensure
+        session1.try &.delete
+        driver1.try &.stop
+        session2.try &.delete
+        driver2.try &.stop
+        TestServer.reset
+      end
+    end
+  end
+end

--- a/src/selenium/service.cr
+++ b/src/selenium/service.cr
@@ -20,6 +20,7 @@ abstract class Selenium::Service
   end
 
   def start
+    find_free_port
     start_process
     verify_running
   end
@@ -36,6 +37,12 @@ abstract class Selenium::Service
   end
 
   abstract def default_port : Int32
+
+  private def find_free_port
+    while listening?
+      @port += 1
+    end
+  end
 
   private def start_process
     @process = Process.new(


### PR DESCRIPTION
Fixes #21 

## Description
This PR is a fix for #21 and an attempt to resolve #24. 
This PR changes update the `Service.start` to check if the default port assigned to the browser service is available or not. 
If not, it will keep increasing the port number until we found an open port 	and use it to run the driver bin command
 This will change will allow multiple instances to run the same browser on different ports, each one with its own context/session. It's very helpful when using Fiber :tada: 

## How it was tested?
Locally by running `SELENIUM_BROWSER=firefox crystal spec -DDEBUG --error-trace  spec/features/session_spec.cr`