### PR TITLE
Firefox: Allow to specify the custom location to Firefox binary

### DIFF
--- a/src/selenium/firefox/capabilities.cr
+++ b/src/selenium/firefox/capabilities.cr
@@ -11,5 +11,6 @@ class Selenium::Firefox::Capabilities < Selenium::Capabilities
     end
 
     property args = [] of String
+    property binary String?
   end
 end


### PR DESCRIPTION
Sample code:

```
capabilities = Selenium::Firefox::Capabilities.new
capabilities.firefox_options.args = [
  "--headless"
]
capabilities.firefox_options.binary = "/Applications/Firefox\ Developer\ Edition.app/Contents/MacOS/firefox"
driver.create_session(capabilities)
```

References: https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions