### PR TITLE
Make Selenium::Session can be serialized/unserialized.

### DIFF
--- a/src/selenium/command_handler.cr
+++ b/src/selenium/command_handler.cr
@@ -1,4 +1,7 @@
+require "json"
+
 class Selenium::CommandHandler
+  include JSON::Serializable
   include DefaultCommands
   getter http_client : HttpClient
 

--- a/src/selenium/http_client.cr
+++ b/src/selenium/http_client.cr
@@ -1,4 +1,8 @@
+require "json"
+
 class Selenium::HttpClient
+  include JSON::Serializable
+
   getter base_url : String
 
   def initialize(@base_url)

--- a/src/selenium/session.cr
+++ b/src/selenium/session.cr
@@ -1,4 +1,8 @@
+require "json"
+
 class Selenium::Session
+  include JSON::Serializable
+
   getter http_client : HttpClient
   getter command_handler : CommandHandler
   getter id : SessionId


### PR DESCRIPTION
Fixed #52

If Selenium::Session can be serialized/unserialized, we can save session into db (e.g. sqlite3), and reuse session connect to the old running driver and session, this make performance better.